### PR TITLE
chore: change return to be json object

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -42,6 +42,12 @@ func (rt *Router) HealthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type getAppIDsOutput struct {
+	ApplicationIDs []string `json:"applicationIDs"`
+}
+
 func (rt *Router) GetAppIDs(w http.ResponseWriter, r *http.Request) {
-	jsonresponse.RespondWithJSON(w, http.StatusOK, rt.Cache.GetAppIDsPassedLimit())
+	jsonresponse.RespondWithJSON(w, http.StatusOK, getAppIDsOutput{
+		ApplicationIDs: rt.Cache.GetAppIDsPassedLimit(),
+	})
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -57,7 +57,9 @@ func TestRouter_GetAppIDs(t *testing.T) {
 
 	c.Equal(http.StatusOK, rr.Code)
 
-	expectedBody, err := json.Marshal([]string{"62c267ea67g6fhns53gdn2sg"})
+	expectedBody, err := json.Marshal(getAppIDsOutput{
+		ApplicationIDs: []string{"62c267ea67g6fhns53gdn2sg"},
+	})
 	c.NoError(err)
 
 	c.Equal(expectedBody, rr.Body.Bytes())


### PR DESCRIPTION
Change getAppIDs endpoint to return JSON object.

Example:
```
{
    "applicationIDs": [
        "61eae7580ae317bbc6c36d94"
    ]
}
```