### PR TITLE
T-15231 Add new logs for rate limit

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -78,7 +78,7 @@ func (c *Cache) getAppLimits() (map[string]repository.AppLimits, error) {
 		return nil, errUnexpectedStatusCodeInLimits
 	}
 
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (c *Cache) getRelaysCount() ([]AppRelaysResponse, error) {
 		return nil, errUnexpectedStatusCodeInRelays
 	}
 
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -184,12 +184,12 @@ func (c *Cache) SetCache() error {
 
 	appLimits, err := c.getAppLimits()
 	if err != nil {
-		return err
+		return fmt.Errorf("err in getAppLimits: %w", err)
 	}
 
 	relaysCount, err := c.getRelaysCount()
 	if err != nil {
-		return err
+		return fmt.Errorf("err in getRelaysCount: %w", err)
 	}
 
 	var appIDsPassedLimit []string
@@ -226,7 +226,7 @@ func (c *Cache) SetCache() error {
 
 	err = c.setFirstDateSurpassed(appIDsToAddFirstSurpassedDate)
 	if err != nil {
-		return err
+		return fmt.Errorf("err in setFirstDateSurpassed: %w", err)
 	}
 
 	c.mutex.Lock()

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -51,7 +51,7 @@ func TestCache_SetCacheFailure(t *testing.T) {
 		http.StatusInternalServerError, "../samples/apps_limits.json")
 
 	err := cache.SetCache()
-	c.Equal(errUnexpectedStatusCodeInLimits, err)
+	c.ErrorIs(err, errUnexpectedStatusCodeInLimits)
 
 	mock.AddMockedResponseFromFile(http.MethodGet, fmt.Sprintf("%s%s", httpDBURL, appLimitsEndpoint),
 		http.StatusOK, "../samples/apps_limits.json")
@@ -60,7 +60,7 @@ func TestCache_SetCacheFailure(t *testing.T) {
 		http.StatusInternalServerError, "../samples/apps_relays.json")
 
 	err = cache.SetCache()
-	c.Equal(errUnexpectedStatusCodeInRelays, err)
+	c.ErrorIs(err, errUnexpectedStatusCodeInRelays)
 
 	mock.AddMockedResponseFromFile(http.MethodGet, fmt.Sprintf("%s%s", httpDBURL, appLimitsEndpoint),
 		http.StatusOK, "../samples/apps_limits.json")
@@ -72,5 +72,5 @@ func TestCache_SetCacheFailure(t *testing.T) {
 		http.StatusInternalServerError, "not ok")
 
 	err = cache.SetCache()
-	c.Equal(errUnexpectedStatusCodeInDateSurpassed, err)
+	c.ErrorIs(err, errUnexpectedStatusCodeInDateSurpassed)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/pokt-foundation/portal-api-go v0.3.4
 	github.com/pokt-foundation/utils-go v0.2.4
+	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 )
 
@@ -18,7 +19,6 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20220913175220-63ea55921009 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
Added logs:
- When an app surpass the daily limit for first time, and every time it triggers the rate-limit after that.
- When it fails to create the router (as error)
- When it fails to set the Cache (as error)
- When it fails to get the counter from the relay-meter (as error)
- When it fails to store the cache (as error)